### PR TITLE
add getBlockReceipts

### DIFF
--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -543,7 +543,7 @@ mod tests {
                             "blobGasUsed": "0x123",
                             "blobGasPrice": "0x12345"
                         }
-                    ]
+                      ]
                     ]"#,
                 )
                 .unwrap(),

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -553,8 +553,8 @@ mod tests {
         assert_eq!(
             receipts.unwrap()[0].kind,
             TransactionReceiptKind::Eip4844 {
-                blob_gas_used: U256::from(291u64),
-                blob_gas_price: U256::from(74565u64)
+                blob_gas_used: U256::new(291),
+                blob_gas_price: U256::new(74_565)
             }
         );
         assert_eq!(latest, 0x1163fd1);

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -227,9 +227,8 @@ mod tests {
     use super::*;
     use crate::{
         eth,
-        types::{BlockSpec, BlockTag, Empty, Hydrated, TransactionReceiptKind},
+        types::{BlockSpec, BlockTag, Empty, Hydrated, TransactionReceiptKind, U256},
     };
-    use ethprim::U256;
     use serde_json::json;
 
     fn roundtrip(

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -227,8 +227,9 @@ mod tests {
     use super::*;
     use crate::{
         eth,
-        types::{BlockTag, Empty, Hydrated},
+        types::{BlockId, BlockTag, Empty, Hydrated},
     };
+    use ethprim::U256;
     use serde_json::json;
 
     fn roundtrip(
@@ -263,15 +264,17 @@ mod tests {
 
     #[test]
     fn batch_request() {
-        let (latest, safe) = call(
+        let (latest, safe, other) = call(
             (
                 (eth::BlockNumber, Empty),
                 (eth::GetBlockByNumber, (BlockTag::Safe.into(), Hydrated::No)),
+                (eth::GetBlockReceipts, (BlockId::Number(U256::new(18_460_382)), )),
             ),
             roundtrip(
                 json!([
                     { "method": "eth_blockNumber", "params": [] },
                     { "method": "eth_getBlockByNumber", "params": ["safe", false] },
+                    { "method": "eth_getBlockReceipts", "params": ["0x119aede"] },
                 ]),
                 serde_json::from_str(
                     r#"[
@@ -520,14 +523,33 @@ mod tests {
                           }
                         ],
                         "withdrawalsRoot": "0x0c6cfaf85519d8d390d3100202d6b9205482382d5f97caca01cf2dbb3a0365d9"
-                      }
+                      },
+                      [
+                        {
+                            "blockHash": "0x79313e7f7904f21e3e3f0abced0cd95b154bca0b4d0c4a5ddfbc70442c7f7205",
+                            "blockNumber": "0x119aede",
+                            "contractAddress": null,
+                            "cumulativeGasUsed": "0xf0c1",
+                            "effectiveGasPrice": "0x2bfe06c9d",
+                            "from": "0xa3b458db8381dcc1fc4529a41ebe2804b07e7ef6",
+                            "gasUsed": "0xf0c1",
+                            "logs": [],
+                            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                            "status": "0x0",
+                            "to": "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
+                            "transactionHash": "0xdf3aa03889d1de2f198f31ccaeeb83019c2f9140cad911011a9d4d2849157393",
+                            "transactionIndex": "0x0",
+                            "type": "0x2"
+                        }
+                    ]
                     ]"#,
                 )
                 .unwrap(),
             ),
         )
         .unwrap();
-
+        println!("{:?}", other);
+        assert!(other.is_none());
         assert_eq!(latest, 0x1163fd1);
         assert_eq!(safe.unwrap().number, 0x1163fa3);
     }

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -227,7 +227,7 @@ mod tests {
     use super::*;
     use crate::{
         eth,
-        types::{BlockId, BlockTag, Empty, Hydrated},
+        types::{BlockSpec, BlockTag, Empty, Hydrated, TransactionReceiptKind},
     };
     use ethprim::U256;
     use serde_json::json;
@@ -264,11 +264,11 @@ mod tests {
 
     #[test]
     fn batch_request() {
-        let (latest, safe, other) = call(
+        let (latest, safe, receipts) = call(
             (
                 (eth::BlockNumber, Empty),
                 (eth::GetBlockByNumber, (BlockTag::Safe.into(), Hydrated::No)),
-                (eth::GetBlockReceipts, (BlockId::Number(U256::new(18_460_382)), )),
+                (eth::GetBlockReceipts, (BlockSpec::Number(U256::new(18_460_382)), )),
             ),
             roundtrip(
                 json!([
@@ -548,8 +548,7 @@ mod tests {
             ),
         )
         .unwrap();
-        println!("{:?}", other);
-        assert!(other.is_none());
+        assert_eq!(receipts.unwrap()[0].kind, TransactionReceiptKind::Eip1559);
         assert_eq!(latest, 0x1163fd1);
         assert_eq!(safe.unwrap().number, 0x1163fa3);
     }

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -539,7 +539,9 @@ mod tests {
                             "to": "0x49048044d57e1c92a77f79988d21fa8faf74e97e",
                             "transactionHash": "0xdf3aa03889d1de2f198f31ccaeeb83019c2f9140cad911011a9d4d2849157393",
                             "transactionIndex": "0x0",
-                            "type": "0x2"
+                            "type": "0x3",
+                            "blobGasUsed": "0x123",
+                            "blobGasPrice": "0x12345"
                         }
                     ]
                     ]"#,

--- a/src/jsonrpc/batch.rs
+++ b/src/jsonrpc/batch.rs
@@ -550,7 +550,13 @@ mod tests {
             ),
         )
         .unwrap();
-        assert_eq!(receipts.unwrap()[0].kind, TransactionReceiptKind::Eip1559);
+        assert_eq!(
+            receipts.unwrap()[0].kind,
+            TransactionReceiptKind::Eip4844 {
+                blob_gas_used: U256::from(291u64),
+                blob_gas_price: U256::from(74565u64)
+            }
+        );
         assert_eq!(latest, 0x1163fd1);
         assert_eq!(safe.unwrap().number, 0x1163fa3);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,10 @@ module! {
         pub struct GetBlockTransactionCountByHash as "eth_getBlockTransactionCountByHash"
             (Digest,) => Option<U256>;
 
+        /// Returns the receipts of a block by number or hash.
+        pub struct GetBlockReceipts as "eth_getBlockReceipts"
+            (BlockNumberOrHash,) => Option<Vec<TransactionReceipt>>;
+
         /// Returns the number of transactions in a block matching the given block number.
         pub struct GetBlockTransactionCountByNumber as "eth_getBlockTransactionCountByNumber"
             (BlockSpec,) => Option<U256>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ module! {
 
         /// Returns the receipts of a block by number or hash.
         pub struct GetBlockReceipts as "eth_getBlockReceipts"
-            (BlockNumberOrHash,) => Option<Vec<TransactionReceipt>>;
+            (BlockId,) => Option<Vec<TransactionReceipt>>;
 
         /// Returns the number of transactions in a block matching the given block number.
         pub struct GetBlockTransactionCountByNumber as "eth_getBlockTransactionCountByNumber"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ module! {
 
         /// Returns the receipts of a block by number or hash.
         pub struct GetBlockReceipts as "eth_getBlockReceipts"
-            (BlockId,) => Option<Vec<TransactionReceipt>>;
+            (BlockSpec,) => Option<Vec<TransactionReceipt>>;
 
         /// Returns the number of transactions in a block matching the given block number.
         pub struct GetBlockTransactionCountByNumber as "eth_getBlockTransactionCountByNumber"

--- a/src/types.rs
+++ b/src/types.rs
@@ -922,7 +922,7 @@ impl Debug for Log {
     }
 }
 
-/// An Ethereum Transaction Receipt
+/// An Ethereum transaction receipt.
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
@@ -930,9 +930,9 @@ pub struct TransactionReceipt {
     /// See `TransactionReceiptKind` for summaries and references.
     #[serde(flatten)]
     pub kind: TransactionReceiptKind,
-    /// The hash of the transaction that emitted this log.
+    /// The hash of the transaction.
     pub transaction_hash: Digest,
-    /// The index of the transaction that emitted this log within the block.
+    /// The index of the transaction within the block it was included.
     pub transaction_index: U256,
     /// The hash of the block containing the transaction.
     pub block_hash: Digest,
@@ -962,6 +962,7 @@ pub struct TransactionReceipt {
     pub status: TransactionReceiptStatus,
 }
 
+/// The status of a `TransactionReceipt` (whether is succeeded or failed).
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum TransactionReceiptStatus {
     /// Status of a failed transaction.
@@ -972,6 +973,7 @@ pub enum TransactionReceiptStatus {
     Success,
 }
 
+/// The type of a `TransactionReceipt`.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum TransactionReceiptKind {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1011,6 +1011,7 @@ impl Debug for TransactionReceipt {
             .field("block_number", &self.block_number)
             .field("from", &self.from)
             .field("to", &self.to)
+            .field("effective_gas_price", &self.effective_gas_price)
             .field("cumulative_gas_used", &self.cumulative_gas_used)
             .field("gas_used", &self.gas_used)
             .field("contract_address", &self.contract_address)

--- a/src/types.rs
+++ b/src/types.rs
@@ -995,7 +995,7 @@ pub enum TransactionReceiptKind {
         #[serde(rename = "blobGasUsed")]
         blob_gas_used: U256,
         /// The actual value per gas deducted from the sender's account for blob gas.
-        /// Only specified for blob transactions as defined by [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844).
+        /// Only specified for blob transactions as defined by EIP-4844.
         #[serde(rename = "blobGasPrice")]
         blob_gas_price: U256,
     },

--- a/src/types.rs
+++ b/src/types.rs
@@ -959,12 +959,10 @@ pub struct TransactionReceipt {
     /// The log bloom filter.
     pub logs_bloom: Bloom,
     /// The transaction status, indicating whether it succeeded or reverted.
-    #[serde(flatten)]
     pub status: TransactionReceiptStatus,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(tag = "status")]
 pub enum TransactionReceiptStatus {
     /// Status of a failed transaction.
     #[serde(rename = "0x0")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -965,6 +965,7 @@ pub struct TransactionReceipt {
     /// Contract address created, or `None` if not a deployment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contract_address: Option<Address>,
+    /// Logs emitted by the transaction.
     pub logs: Vec<Log>,
     /// The log bloom filter.
     pub logs_bloom: Bloom,

--- a/src/types.rs
+++ b/src/types.rs
@@ -926,7 +926,7 @@ impl Debug for Log {
 #[derive(Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransactionReceipt {
-    #[serde(rename = "type")]
+    #[serde(flatten)]
     pub kind: TransactionReceiptKind,
     /// The hash of the transaction that emitted this log.
     pub transaction_hash: Digest,
@@ -964,7 +964,7 @@ pub struct TransactionReceipt {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type")]
 pub enum TransactionReceiptKind {
     #[serde(rename = "0x0")]
     Legacy,
@@ -976,9 +976,11 @@ pub enum TransactionReceiptKind {
     Eip4844 {
         /// The amount of blob gas used for this specific transaction.
         /// Only specified for blob transactions as defined by EIP-4844.
+        #[serde(rename = "blobGasUsed")]
         blob_gas_used: U256,
         /// The actual value per gas deducted from the sender's account for blob gas.
         /// Only specified for blob transactions as defined by [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844).
+        #[serde(rename = "blobGasPrice")]
         blob_gas_price: U256,
     },
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -944,7 +944,7 @@ pub struct TransactionReceipt {
     /// The price paid post-execution by the transaction (i.e. base fee + priority fee).
     /// Both fields in 1559-style transactions are *maximums* (max fee + max priority fee), the
     /// amount that's actually paid by users can only be determined post-execution.
-    effective_gas_price: U256,
+    pub effective_gas_price: U256,
     /// The sum of gas used by this transaction and all preceding transactions in the same block.
     pub cumulative_gas_used: U256,
     /// The amount of gas used for this specific transaction alone.

--- a/src/types.rs
+++ b/src/types.rs
@@ -959,15 +959,17 @@ pub struct TransactionReceipt {
     /// The log bloom filter.
     pub logs_bloom: Bloom,
     /// The transaction status, indicating whether it succeeded or reverted.
+    #[serde(flatten)]
     pub status: TransactionReceiptStatus,
 }
 
-/// Status: either 1 (success) or 0 (failure).
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(tag = "status")]
 pub enum TransactionReceiptStatus {
+    /// Status of a failed transaction.
     #[serde(rename = "0x0")]
     Failure,
+    /// Status of a successful transaction.
     #[serde(rename = "0x1")]
     Success,
 }
@@ -978,16 +980,16 @@ pub enum TransactionReceiptKind {
     /// - Legacy: The original transaction type
     #[serde(rename = "0x0")]
     Legacy,
-    /// - EIP2930: Optional access lists
-    /// https://eips.ethereum.org/EIPS/eip-2930
+    /// - EIP-2930: Optional access lists
+    ///   https://eips.ethereum.org/EIPS/eip-2930
     #[serde(rename = "0x1")]
     Eip2930,
-    /// EIP1559: Fee market change for ETH 1.0 chain
-    /// - https://eips.ethereum.org/EIPS/eip-1559
+    /// EIP-1559: Fee market change for ETH 1.0 chain
+    ///   https://eips.ethereum.org/EIPS/eip-1559
     #[serde(rename = "0x2")]
     Eip1559,
-    /// EIP4844: Shard Blob Transactions
-    /// - https://eips.ethereum.org/EIPS/eip-4844
+    /// EIP-4844: Shard Blob Transactions
+    ///   https://eips.ethereum.org/EIPS/eip-4844
     #[serde(rename = "0x3")]
     Eip4844 {
         /// The amount of blob gas used for this specific transaction.

--- a/src/types.rs
+++ b/src/types.rs
@@ -958,7 +958,7 @@ pub struct TransactionReceipt {
     pub logs: Vec<Log>,
     /// The log bloom filter.
     pub logs_bloom: Bloom,
-    #[serde(flatten)]
+    /// The transaction status, indicating whether it succeeded or reverted.
     pub status: TransactionReceiptStatus,
 }
 


### PR DESCRIPTION
1. Creating new type `TransactionReceipt` along with enums:
   - `TransactionReceiptKind` (for the transaction "type" field).
   - `TransactionReceiptStatus` (for success vs failed transactions)
2. Add ethrpc method `eth_getBlockRecipts` according to the spec defined here is as in https://ethereum.github.io/execution-apis/api-documentation/#eth_getblockreceipts