### PR TITLE
Add eth_getTransactionReceipt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ module! {
         /// Returns information about a transaction requested by transaction hash.
         pub struct GetTransactionByHash as "eth_getTransactionByHash"
             (Digest,) => Option<SignedTransaction>;
+
+        /// Returns the receipt of a transaction by transaction hash.
+        pub struct GetTransactionReceipt as "eth_getTransactionReceipt"
+            (Digest,) => Option<TransactionReceipt>;
     }
 }
 


### PR DESCRIPTION
Introducing method to getTransactionReceipt documented as is here: https://ethereum.github.io/execution-apis/api-documentation/#eth_gettransactionreceipt

Note that this is based on main but depends a branch that has not yet been merged (so it looks weird and isn't passing CI). Once the other one hits main I will rebase.
