### PR TITLE
Quick Pass Through the Easy Ones

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ module! {
 
         /// Returns the value from a storage position at a given address.
         pub struct GetStorageAt as "eth_getStorageAt"
-            (Address, U256, Option<BlockSpec>) => [u8; 32] [serialization::bytearray];
+            (Address, U256, Option<BlockId>) => [u8; 32] [serialization::bytearray];
 
         /// Returns information about a transaction by block hash and transaction index position.
         pub struct GetTransactionByBlockHashAndIndex as "eth_getTransactionByBlockHashAndIndex"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ module! {
 
         /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
         pub struct EstimateGas as "eth_estimateGas"
-            (TransactionCall, BlockId) => U256;
+            (TransactionCall, BlockSpec) => U256;
 
         /// Returns the current price per gas in wei.
         pub struct GasPrice as "eth_gasPrice"
@@ -51,7 +51,7 @@ module! {
 
         /// Returns the balance of the account of given address.
         pub struct GetBalance as "eth_getBalance"
-            (Address, Option<BlockSpec>) => U256;
+            (Address, Option<BlockId>) => U256;
 
         /// Returns information about a block by hash.
         pub struct GetBlockByHash as "eth_getBlockByHash"
@@ -99,7 +99,7 @@ module! {
 
         /// Returns the value from a storage position at a given address.
         pub struct GetTransactionCount as "eth_getTransactionCount"
-            (Address, Option<BlockSpec>) => U256;
+            (Address, Option<BlockId>) => U256;
 
         /// Returns the receipt of a transaction by transaction hash.
         pub struct GetTransactionReceipt as "eth_getTransactionReceipt"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ module! {
 
         /// Returns the value from a storage position at a given address.
         pub struct GetStorageAt as "eth_getStorageAt"
-            (Address, U256, Option<BlockSpec>) => Vec<u8> [serialization::bytes];
+            (Address, U256, Option<BlockSpec>) => [u8; 32] [serialization::bytearray];
 
         /// Returns information about a transaction by block hash and transaction index position.
         pub struct GetTransactionByBlockHashAndIndex as "eth_getTransactionByBlockHashAndIndex"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,22 @@ module! {
         pub struct Call as "eth_call"
             (TransactionCall, BlockId) => Vec<u8> [serialization::bytes];
 
+        /// Returns the chain ID of the current network
+        pub struct ChainId as "eth_chainId"
+            Empty => U256;
+
+        /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+        pub struct EstimateGas as "eth_estimateGas"
+            (TransactionCall, BlockId) => U256;
+
+        /// Returns the current price per gas in wei.
+        pub struct GasPrice as "eth_gasPrice"
+            Empty => U256;
+
+        /// Returns the balance of the account of given address.
+        pub struct GetBalance as "eth_getBalance"
+            (Address, Option<BlockSpec>) => U256;
+
         /// Returns information about a block by hash.
         pub struct GetBlockByHash as "eth_getBlockByHash"
             (Digest, Hydrated) => Option<Block>;
@@ -45,13 +61,13 @@ module! {
         pub struct GetBlockByNumber as "eth_getBlockByNumber"
             (BlockSpec, Hydrated) => Option<Block>;
 
-        /// Returns the number of transactions in a block from a block matching the given block hash.
-        pub struct GetBlockTransactionCountByHash as "eth_getBlockTransactionCountByHash"
-            (Digest,) => Option<U256>;
-
         /// Returns the receipts of a block by number or hash.
         pub struct GetBlockReceipts as "eth_getBlockReceipts"
             (BlockSpec,) => Option<Vec<TransactionReceipt>>;
+
+        /// Returns the number of transactions in a block from a block matching the given block hash.
+        pub struct GetBlockTransactionCountByHash as "eth_getBlockTransactionCountByHash"
+            (Digest,) => Option<U256>;
 
         /// Returns the number of transactions in a block matching the given block number.
         pub struct GetBlockTransactionCountByNumber as "eth_getBlockTransactionCountByNumber"
@@ -65,6 +81,10 @@ module! {
         pub struct GetLogs as "eth_getLogs"
             (LogFilter,) => Vec<Log>;
 
+        /// Returns the value from a storage position at a given address.
+        pub struct GetStorageAt as "eth_getStorageAt"
+            (Address, U256, Option<BlockSpec>) => Vec<u8> [serialization::bytes];
+
         /// Returns information about a transaction by block hash and transaction index position.
         pub struct GetTransactionByBlockHashAndIndex as "eth_getTransactionByBlockHashAndIndex"
             (Digest, U256) => Option<SignedTransaction>;
@@ -77,9 +97,33 @@ module! {
         pub struct GetTransactionByHash as "eth_getTransactionByHash"
             (Digest,) => Option<SignedTransaction>;
 
+        /// Returns the value from a storage position at a given address.
+        pub struct GetTransactionCount as "eth_getTransactionCount"
+            (Address, Option<BlockSpec>) => U256;
+
         /// Returns the receipt of a transaction by transaction hash.
         pub struct GetTransactionReceipt as "eth_getTransactionReceipt"
             (Digest,) => Option<TransactionReceipt>;
+
+        /// Returns the number of uncles in a block from a block matching the given block hash.
+        pub struct GetUncleCountByBlockHash as "eth_getUncleCountByBlockHash"
+            (Digest,) => Option<U256>;
+
+        /// Returns the number of uncles in a block from a block matching the given block number.
+        pub struct GetUncleCountByBlockNumber as "eth_getUncleCountByBlockNumber"
+            (BlockSpec,) => Option<U256>;
+
+        /// Returns the current maxPriorityFeePerGas per gas in wei.
+        pub struct MaxPriorityFeePerGas as "eth_maxPriorityFeePerGas"
+            Empty => U256;
+
+        /// Creates a filter in the node, to notify when a new block arrives.
+        pub struct NewBlockFilter as "eth_newBlockFilter"
+            Empty => U256;
+
+        /// Creates a filter in the node, to notify when new pending transactions arrive.
+        pub struct NewPendingTransactionFilter as "eth_newPendingTransactionFilter"
+            Empty => U256;
     }
 }
 


### PR DESCRIPTION
Not sure if you wanted the all to come in one at a time, but this quick pass adds nearly all the missing `eth_*` methods that don't require new types.

I moved `GetBlockTransactionCountByHash` down one to preserve alphabetical ordering.

There are still a few important ones coming, but the remaining ones are more complex than these and in some cases require new types.

Let me know if you'd like these to be split. 